### PR TITLE
Update download ID retrieval

### DIFF
--- a/edd-license-free-download.php
+++ b/edd-license-free-download.php
@@ -263,7 +263,7 @@ if( ! class_exists( 'EDD_License' ) ) {
 		if ( ! $license ) {
 			return false;
 		}
-		if ( ! in_array( $license->status, array( 'expired', 'revoked' ), true ) ) {
+		if ( ! in_array( $license->status, array( 'expired', 'revoked', 'disabled' ), true ) ) {
 			return true;
 		}
 

--- a/edd-license-free-download.php
+++ b/edd-license-free-download.php
@@ -276,10 +276,10 @@ if( ! class_exists( 'EDD_License' ) ) {
 	 *
 	 * @param string $license_key
 	 *
-	 * @return int
+	 * @return array
 	 */
 	public static function get_license_product_ids( $license_key ) {
-		return edd_software_licensing()->get_download_id_by_license( $license_key );
+		return (array) edd_software_licensing()->get_download_id_by_license( $license_key );
 	}
 
 
@@ -294,10 +294,10 @@ if( ! class_exists( 'EDD_License' ) ) {
 		$free_products = array_map( 'absint', self::get_free_products_ids( $download_id ) );
 
 		// ids of product the license is for
-		$licensed_product = absint( self::get_license_product_ids( $license_key ) );
+		$licensed_products = array_map( 'absint', self::get_license_product_ids( $license_key ) );
 
 		// store the status of the license products. i.e whether they are among the products available for free or not
-		if ( in_array( $licensed_product, $free_products, true ) ) {
+		if ( array_intersect( $free_products, $licensed_products ) ) {
 			return true;
 		}
 

--- a/edd-license-free-download.php
+++ b/edd-license-free-download.php
@@ -272,7 +272,9 @@ if( ! class_exists( 'EDD_License' ) ) {
 
 
 	/**
-	 * Get the products id associated with a license key
+	 * Get the product id associated with a license key.
+	 * For backwards compatibility, this is returned as an array even though
+	 * the SL function returns an integer.
 	 *
 	 * @param string $license_key
 	 *

--- a/edd-license-free-download.php
+++ b/edd-license-free-download.php
@@ -280,7 +280,9 @@ if( ! class_exists( 'EDD_License' ) ) {
 	 * @return array
 	 */
 	public static function get_license_product_ids( $license_key ) {
-		return (array) edd_software_licensing()->get_download_id_by_license( $license_key );
+		$licensed_products = (array) edd_software_licensing()->get_download_id_by_license( $license_key );
+
+		return array_filter( $licensed_products );
 	}
 
 
@@ -315,7 +317,9 @@ if( ! class_exists( 'EDD_License' ) ) {
 	 * @return array
 	 */
 	public static function get_free_products_ids( $product_id ) {
-		return (array) get_post_meta( $product_id, '_edd_lfd_products', true );
+		$free_products = (array) get_post_meta( $product_id, '_edd_lfd_products', true );
+
+		return array_filter( $free_products );
 	}
 
 	/**

--- a/edd-license-free-download.php
+++ b/edd-license-free-download.php
@@ -291,10 +291,10 @@ if( ! class_exists( 'EDD_License' ) ) {
 	public static function comparison( $license_key, $download_id ) {
 
 		// products ids (that was saved in 'chosen' select box) the license will be checked against
-		$free_products = self::get_free_products_ids( $download_id );
+		$free_products = array_map( 'absint', self::get_free_products_ids( $download_id ) );
 
 		// ids of product the license is for
-		$licensed_product = self::get_license_product_ids( $license_key );
+		$licensed_product = absint( self::get_license_product_ids( $license_key ) );
 
 		// store the status of the license products. i.e whether they are among the products available for free or not
 		if ( in_array( $licensed_product, $free_products, true ) ) {

--- a/edd-license-free-download.php
+++ b/edd-license-free-download.php
@@ -276,28 +276,10 @@ if( ! class_exists( 'EDD_License' ) ) {
 	 *
 	 * @param string $license_key
 	 *
-	 * @return array
+	 * @return int
 	 */
 	public static function get_license_product_ids( $license_key ) {
-
-		global $wpdb;
-
-		// The edd_license post ID of the license key
-		$license_post_id = $wpdb->get_var(
-		$wpdb->prepare(
-		"SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_edd_sl_key' AND meta_value = %s", $license_key )
-		);
-
-		$payment_id = get_post_meta( $license_post_id, '_edd_sl_payment_id', true );
-
-		$get_product_id_for_payment = edd_get_payment_meta_cart_details( $payment_id );
-
-		$products_ids_for_payment = array();
-		foreach ( $get_product_id_for_payment as $key => $products ) {
-			$products_ids_for_payment[] = $products['id'];
-		}
-
-		return $products_ids_for_payment;
+		return edd_software_licensing()->get_download_id_by_license( $license_key );
 	}
 
 
@@ -311,14 +293,12 @@ if( ! class_exists( 'EDD_License' ) ) {
 		// products ids (that was saved in 'chosen' select box) the license will be checked against
 		$free_products = self::get_free_products_ids( $download_id );
 
-		// ids of products the license is for
-		$license_products = self::get_license_product_ids( $license_key );
+		// ids of product the license is for
+		$licensed_product = self::get_license_product_ids( $license_key );
 
 		// store the status of the license products. i.e whether they are among the products available for free or not
-		foreach ( $license_products as $product ) {
-			if ( in_array( $product, $free_products ) ) {
-				return true;
-			}
+		if ( in_array( $licensed_product, $free_products, true ) ) {
+			return true;
 		}
 
 		// return false if the return above doesn't return true

--- a/edd-license-free-download.php
+++ b/edd-license-free-download.php
@@ -305,17 +305,8 @@ if( ! class_exists( 'EDD_License' ) ) {
 	 * @return array
 	 */
 	public static function get_free_products_ids( $product_id ) {
-		global $wpdb;
-
-		// return multi-dimensional array of all products set to free download
-		$query = $wpdb->get_col(
-		$wpdb->prepare( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = '_edd_lfd_products' AND post_id = %d", $product_id )
-		);
-
-		return unserialize( $query[0] );
-
+		return (array) get_post_meta( $product_id, '_edd_lfd_products', true );
 	}
-
 
 	/**
 	 * Add product to cart and subsequently checkout

--- a/edd-license-free-download.php
+++ b/edd-license-free-download.php
@@ -260,6 +260,9 @@ if( ! class_exists( 'EDD_License' ) ) {
 	 */
 	public static function validate_license( $license_key ) {
 		$license = edd_software_licensing()->get_license( $license_key );
+		if ( ! $license ) {
+			return false;
+		}
 		if ( ! in_array( $license->status, array( 'expired', 'revoked' ), true ) ) {
 			return true;
 		}

--- a/edd-license-free-download.php
+++ b/edd-license-free-download.php
@@ -242,7 +242,6 @@ if( ! class_exists( 'EDD_License' ) ) {
 		}
 	}
 
-
 	/**
 	 * Verify the license key hasn't expired
 	 *
@@ -253,23 +252,13 @@ if( ! class_exists( 'EDD_License' ) ) {
 	 * @return bool
 	 */
 	public static function validate_license( $license_key ) {
-		global $wpdb;
-
-		// The edd_license post ID of the license key
-		$license_post_id = $wpdb->get_var(
-		$wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_edd_sl_key' AND meta_value = %s", $license_key )
-		 );
-
-		$obj    = edd_software_licensing();
-		$status = $obj->get_license_status( $license_post_id );
-
-		if ( $status != 'expired' ||  $status != 'revoked') {
+		$license = edd_software_licensing()->get_license( $license_key );
+		if ( ! in_array( $license->status, array( 'expired', 'revoked' ), true ) ) {
 			return true;
-		} else {
-			return false;
 		}
-	}
 
+		return false;
+	}
 
 	/**
 	 * Get the product id associated with a license key.


### PR DESCRIPTION
The get_license_product_ids method was querying the database for post_meta, but the license keys are now stored in their own table.

Additionally, software licensing provides a helper function, edd_software_licensing()->get_download_id_by_license(), to get the proper download ID from the database, so we're changing to use that.

The updated function no longer returns an array, so the comparison has been updated accordingly.

Fixes #6